### PR TITLE
Implement Deferred.Result.fail

### DIFF
--- a/src/deferred_result.ml
+++ b/src/deferred_result.ml
@@ -31,4 +31,7 @@ include Monad.Make2 (struct
 
 let ignore = ignore_m
 
+let fail x = Deferred.return (Error x)
+let failf format = Printf.ksprintf fail format
+
 let map_error t ~f = Deferred.map t ~f:(fun r -> Result.map_error r ~f)

--- a/src/deferred_result.mli
+++ b/src/deferred_result.mli
@@ -4,6 +4,11 @@ include Monad.S2 with type ('a, 'b) t = ('a, 'b) Result.t Deferred1.t (** @open 
 
 val ignore : (_, 'err) t -> (unit, 'err) t
 
+val fail : 'err -> (_, 'err) t
+
+(** e.g., [failf "Couldn't find bloogle %s" (Bloogle.to_string b)]. *)
+val failf : ('a, unit, string, (_, string) t) format4 -> 'a
+
 val map_error : ('ok, 'error1) t -> f:('error1 -> 'error2) -> ('ok, 'error2) t
 
 (** [combine] waits on both inputs and combines their results using [Result.combine]. *)


### PR DESCRIPTION
I often have the case where I want to create a Deferred.Result.t. Creating an `Ok` value is easy with `Deferred.Result.return` but for the `Error` case you need `Deferred.return @@ Error x` which is asymetric to the regular `Result` module which has `Result.fail` to construct `Error`.

This pull requests adds `fail`/`failf`, so `Deferred.Result` is more similar to `Result`.